### PR TITLE
Add the about section skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ It's totally normal if you see links in pages that link to other folders. That j
 
 This page should be seen as a table of contents for the documentation.
 
+## About AERO
+To find out information about AERO and related things, visit the ["About" section](about/about.md).
+
 ## Sub-Teams
 The following are entry-point links for the various sub-teams.
 

--- a/about/about.md
+++ b/about/about.md
@@ -1,0 +1,19 @@
+# About AERO
+
+UVic AERO is a student engineering competition team at the University of Victoria.
+
+__Work in progress__
+
+## Organization __Work in progress__
+This section will talk about:
+* How the team is organized
+* Faculty support
+* Funding
+* etc
+
+## Competition
+Every year, AERO participates in a competition organized by [Unmanned Systems Canada](https://www.unmannedsystems.ca/)
+To read more about how this competition is run and how it affects the work we do at AERO, click [here](./competition.md)
+
+## History __Work in progress__
+This section will talk about the history of AERO

--- a/about/competition.md
+++ b/about/competition.md
@@ -1,0 +1,5 @@
+# Competition
+This page will describe USC competition:
+* Format
+* Conops
+* Anything else relevant


### PR DESCRIPTION
Added an about section.
Right now its just a skeleton but it seemed good to have a place to put information of a more general order about AERO.